### PR TITLE
Add volume field to stock data scraping and JSON output

### DIFF
--- a/internal/stockdata/stock_data.go
+++ b/internal/stockdata/stock_data.go
@@ -23,6 +23,7 @@ type StockData struct {
 	PER           string `json:"per,omitempty"`
 	PBR           string `json:"pbr,omitempty"`
 	MarketCap     string `json:"marketCap,omitempty"`
+	Volume        string `json:"volume,omitempty"`
 }
 
 // ValidateTicker checks if the ticker is valid (only contains letters and numbers)
@@ -72,6 +73,12 @@ func GetStockData(ticker string) (StockData, error) {
 	per := strings.TrimSpace(doc.Find("#stockinfo_i3 tbody tr:nth-child(1) td:nth-child(1)").Text())  // PER
 	pbr := strings.TrimSpace(doc.Find("#stockinfo_i3 tbody tr:nth-child(1) td:nth-child(2)").Text())  // PBR
 	marketCap := strings.TrimSpace(doc.Find("#stockinfo_i3 tbody tr:nth-child(2) td").First().Text()) // 時価総額
+	volumeRaw := strings.TrimSpace(doc.Find("#kobetsu_left table:nth-of-type(2) tbody tr:nth-child(1) td").First().Text())
+	if volumeRaw == "" {
+		volumeRaw = strings.TrimSpace(doc.Find("body div:nth-child(1) div:nth-child(3) div:nth-child(1) div:nth-child(3) table:nth-of-type(2) tbody tr:nth-child(1) td").First().Text())
+	}
+	volume := strings.TrimSpace(strings.ReplaceAll(volumeRaw, "\u00a0", " "))
+	volume = strings.TrimSpace(strings.TrimSuffix(volume, "株"))
 	return StockData{
 		Ticker:        ticker,
 		CompanyName:   companyName,
@@ -81,6 +88,7 @@ func GetStockData(ticker string) (StockData, error) {
 		PER:           per,
 		PBR:           pbr,
 		MarketCap:     marketCap,
+		Volume:        volume,
 	}, nil
 }
 


### PR DESCRIPTION
### Motivation
- Add the trading volume (出来高) to the scraped stock data so the JSON output includes a `volume` field for downstream consumers.
- The volume is present on the Kabutan page and must be extracted from the page elements referenced in the request.

### Description
- Added a `Volume string `json:"volume,omitempty"`` field to the `StockData` struct.
- Scrapes the volume using a primary selector `#kobetsu_left table:nth-of-type(2) tbody tr:nth-child(1) td` and falls back to the longer `body div:nth-child(1) div:nth-child(3) div:nth-child(1) div:nth-child(3) table:nth-of-type(2) tbody tr:nth-child(1) td` path if the primary selector is empty.
- Normalizes the scraped string by replacing non-breaking spaces with regular spaces and trimming the trailing `株` suffix so the value is suitable for JSON output.
- Includes the `volume` value in the JSON returned by `GetStockDataJSON` without changing existing caching or DB persistence behavior.

### Testing
- No automated tests were executed as part of this change.
- `gofmt` was run on the modified file to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ad92d36c83308a62da5c5d90a868)