### PR TITLE
Use http.Client with browser-like headers and timeout for Kabutan requests

### DIFF
--- a/internal/stockdata/stock_data.go
+++ b/internal/stockdata/stock_data.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	urlpkg "net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -47,14 +48,31 @@ func GetStockData(ticker string) (StockData, error) {
 	)
 
 	url := fmt.Sprintf(KabutanURL, ticker)
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return StockData{}, fmt.Errorf("failed to build request: %v", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "ja,en-US;q=0.9,en;q=0.8")
+	req.Header.Set("Referer", "https://kabutan.jp/")
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return StockData{}, fmt.Errorf("failed to fetch data: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return StockData{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		parsed, parseErr := urlpkg.Parse(url)
+		host := ""
+		if parseErr == nil {
+			host = parsed.Host
+		}
+		return StockData{}, fmt.Errorf("unexpected status code: %d from %s", resp.StatusCode, host)
 	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)


### PR DESCRIPTION
### Motivation
- Kabutan requests were returning 403, so the scraper needs to present as a browser to avoid blocking.
- Requests should have a reasonable timeout to avoid hanging the service when the remote site is slow.
- Error messages should include host details to make remote request failures easier to diagnose.

### Description
- Replaced `http.Get` with an explicit `http.Client` and `http.NewRequest` in `GetStockData` (internal/stockdata/stock_data.go). 
- Added browser-like headers: `User-Agent`, `Accept`, `Accept-Language`, and `Referer` to the request.
- Set a 15s timeout on the `http.Client` used for Kabutan requests.
- Enhanced non-200 error reporting to include the target host by parsing the request URL, and imported `net/url` as `urlpkg` to support this.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e332145888330bd775694c47f457d)