### PR TITLE
Throttle Kabutan scrape requests and harden HTTP client

### DIFF
--- a/internal/stockdata/stock_data.go
+++ b/internal/stockdata/stock_data.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	urlpkg "net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -47,14 +48,32 @@ func GetStockData(ticker string) (StockData, error) {
 	)
 
 	url := fmt.Sprintf(KabutanURL, ticker)
-	resp, err := http.Get(url)
+	time.Sleep(400 * time.Millisecond)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return StockData{}, fmt.Errorf("failed to build request: %v", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "ja,en-US;q=0.9,en;q=0.8")
+	req.Header.Set("Referer", "https://kabutan.jp/")
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return StockData{}, fmt.Errorf("failed to fetch data: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return StockData{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		parsed, parseErr := urlpkg.Parse(url)
+		host := ""
+		if parseErr == nil {
+			host = parsed.Host
+		}
+		return StockData{}, fmt.Errorf("unexpected status code: %d from %s", resp.StatusCode, host)
 	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)


### PR DESCRIPTION
### Motivation
- Reduce the chance of being blocked by Kabutan by presenting requests like a browser and limiting request rate. 
- Prevent long hangs when the remote site is slow by using a client-level timeout. 
- Make remote failures easier to diagnose by including host information in non-200 errors.

### Description
- Replaced `http.Get` with an explicit `http.Client` and `http.NewRequest` and added browser-like headers (`User-Agent`, `Accept`, `Accept-Language`, `Referer`) in `internal/stockdata/stock_data.go`.
- Set a `15 * time.Second` timeout on the `http.Client` and enhanced non-200 error reporting to include the target host via `urlpkg.Parse` (imported as `net/url`).
- Added `time.Sleep(400 * time.Millisecond)` immediately before sending Kabutan requests to throttle the scrape rate.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e332145888330bd775694c47f457d)