### PR TITLE
Run Selenium Grid as a single node and cap JVM heap for low-memory VPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,33 @@ mysql -h 127.0.0.1 -P 3307 -u "$MARIADB_USER" -p"$MARIADB_PASSWORD" "$MARIADB_DA
 
 ---
 
+## Selenium Grid (single-node) ops checklist
+
+1) Start (single node is the default in this compose file):
+```bash
+docker compose up -d
+```
+
+2) Verify exactly one node container is running and hub is healthy:
+```bash
+docker ps --filter "name=selenium-node"
+docker inspect --format='{{.State.Health.Status}}' jpx-scraper-selenium-hub-1
+```
+
+3) Smoke test: confirm the scraper can reach Selenium via the hub:
+```bash
+curl -s "http://localhost:8082/scrape?ticker=8306" >/dev/null
+docker logs jpx-scraper | tail -n 50
+```
+
+4) Resource check (low-memory VPS):
+```bash
+free -hm
+docker stats --no-stream
+```
+
+---
+
 ## Environment & Compose (compact profile)
 
 Key variables (from `.env`):
@@ -199,4 +226,3 @@ Health checks (Compose):
 
 ## License
 MIT
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       retries: 5
       start_period: 10s
     restart: unless-stopped
+    environment:
+      - SE_JAVA_OPTS=-Xms64m -Xmx256m
     mem_limit: 256m
     networks:
       - app-network
@@ -60,7 +62,7 @@ services:
       - SE_NODE_OVERRIDE_MAX_SESSIONS=true
       - SE_NODE_SESSION_TIMEOUT=120
       - SE_ENABLE_TRACING=false
-      - JAVA_OPTS=-Xmx256m
+      - SE_JAVA_OPTS=-Xms128m -Xmx256m
     restart: unless-stopped
     shm_size: 256m
     mem_limit: 384m
@@ -105,4 +107,3 @@ volumes:
 networks:
   app-network:
     driver: bridge
-


### PR DESCRIPTION
### Motivation
- Reduce memory usage and ensure stable operation on a low-memory (3.6GB, no swap) VPS by running a single Selenium node by default. 
- Prevent accidental multi-node scale-ups and make `docker compose up -d` start just one node without extra flags. 
- Limit JVM heap for hub and node to keep container memory footprints predictable.

### Description
- Updated `docker-compose.yml` to add `SE_JAVA_OPTS=-Xms64m -Xmx256m` for `selenium-hub` and replace `JAVA_OPTS` with `SE_JAVA_OPTS=-Xms128m -Xmx256m` for `selenium-node` to cap Java heap sizes. 
- Kept `SE_NODE_MAX_SESSIONS=1` and existing `mem_limit` / `shm_size` settings so concurrent browser sessions and container memory remain constrained. 
- Added a short ops checklist to `README.md` under "Selenium Grid (single-node) ops checklist" describing `docker compose up -d`, how to verify exactly one node and hub health, a scraper smoke test, and simple resource checks (`free -hm` / `docker stats --no-stream`).

### Testing
- No automated tests were run for these documentation and compose configuration changes. 
- Recommended manual verification steps are documented in the appended README checklist (start stack, confirm one `selenium-node`, verify hub health, run scraper smoke test, and check host/container resources).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978539ede088330820a83ed31192875)