### PR TITLE
docs: remove License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,3 @@ Health checks (Compose):
 - **Worker/Scheduler** to decouple scraping from HTTP path.
 
 ---
-
-## License
-MIT


### PR DESCRIPTION
### Motivation
- Remove the explicit `License` section from `README.md` so the repository README does not declare a license and stays aligned with the project's current policy on license statements.

### Description
- Deleted the trailing `## License` section (containing `MIT`) from `README.md`, leaving the document ending at the Roadmap/section separator.

### Testing
- This is a documentation-only change so no runtime tests were required and nothing in the build/test matrix was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16446aa008330a397086fab86d400)