### PR TITLE
[codex] add WSL compose override and fix health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,35 @@ Later (when KVS is added), the DB freshness window can be lengthened (e.g., 30 d
 docker compose --env-file .env up -d --build
 ```
 
+### WSL local override
+
+WSL Ubuntu で他プロジェクトから API として再利用するローカル運用では、VPS 用のベース構成はそのままにして `docker-compose.wsl.yml` を重ねます。
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.wsl.yml \
+  --env-file .env \
+  up -d --build
+```
+
+この override は以下だけをローカル向けに変えます。
+- `mariadb` サービスの実体を `mysql:8.0` に切り替える
+- ホスト公開ポートを `13306` / `14444` / `18082` に上げる
+- ベースの `docker-compose.yml` は変更しないので、VPS には影響しない
+
+ローカル `.env` には少なくとも次を入れてください。
+
+```env
+MYSQL_ROOT_PASSWORD=********
+MYSQL_DATABASE=jpx
+MYSQL_USER=jpx
+MYSQL_PASSWORD=********
+MYSQL_HOST_PORT=13306
+SELENIUM_HOST_PORT=14444
+SCRAPER_HOST_PORT=18082
+```
+
 2) Call the API twice (second call should be fast and DB-backed):
 ```bash
 time curl -s "http://localhost:8082/scrape?ticker=8306" >/dev/null

--- a/deploy-jpx-scraper.sh
+++ b/deploy-jpx-scraper.sh
@@ -50,15 +50,27 @@ wait_healthy() {
   local deadline=$((SECONDS + WAIT_TIMEOUT))
   echo "Waiting for service '$svc' to become healthy (timeout: ${WAIT_TIMEOUT}s)…"
   while true; do
-    local status
-    status="$(docker inspect -f '{{.State.Health.Status}}' "$svc" 2>/dev/null || true)"
-    if [[ "$status" == "healthy" ]]; then
-      echo "Service '$svc' is healthy."
-      return 0
+    local container_ids
+    container_ids="$(docker compose --env-file "$ENV_FILE" ps -q "$svc" 2>/dev/null || true)"
+    if [[ -n "$container_ids" ]]; then
+      local all_healthy=1
+      local cid
+      for cid in $container_ids; do
+        local status
+        status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || true)"
+        if [[ "$status" != "healthy" && "$status" != "running" ]]; then
+          all_healthy=0
+          break
+        fi
+      done
+      if (( all_healthy )); then
+        echo "Service '$svc' is healthy."
+        return 0
+      fi
     fi
     if (( SECONDS >= deadline )); then
       echo "Timed out waiting for '$svc' to be healthy." >&2
-      docker ps
+      docker compose --env-file "$ENV_FILE" ps || true
       return 1
     fi
     sleep 3
@@ -80,4 +92,4 @@ echo "Deployment completed."
 echo "• Nodes: ${NODES}"
 echo "• Prune: ${PRUNE_MODE}"
 echo "• Check:  docker compose ps"
-echo "• Logs:   docker logs mariadb --tail=50"
+echo "• Logs:   docker compose --env-file \"$ENV_FILE\" logs --tail=50 mariadb"

--- a/docker-compose.wsl.yml
+++ b/docker-compose.wsl.yml
@@ -1,0 +1,31 @@
+services:
+  mariadb:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    command:
+      - --innodb_buffer_pool_size=128M
+      - --max_connections=50
+      - --table_open_cache=256
+      - --tmp_table_size=32M
+      - --performance_schema=OFF
+    ports:
+      - "${MYSQL_HOST_PORT:-13306}:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping --silent --protocol=TCP -h 127.0.0.1 -uroot -p\"$${MYSQL_ROOT_PASSWORD}\""]
+
+  selenium-hub:
+    ports:
+      - "${SELENIUM_HOST_PORT:-14444}:4444"
+
+  scraper:
+    ports:
+      - "${SCRAPER_HOST_PORT:-18082}:8081"
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
## What changed
- added `docker-compose.wsl.yml` for WSL-local overrides so local MySQL and higher host ports can be used without changing the VPS base compose file
- fixed `deploy-jpx-scraper.sh` health waiting to inspect actual compose container IDs instead of raw service names
- documented the WSL override workflow in `README.md`

## Why
- the deploy script could time out waiting on `mariadb` even when the container was already healthy because it inspected the wrong target
- local WSL reuse as an API needs ports that are less likely to conflict, but that should not alter the VPS MariaDB-based deployment

## Impact
- VPS keeps using the base `docker-compose.yml` with MariaDB and the existing published ports
- WSL local runs can opt into `docker-compose.wsl.yml` to switch the DB image and host ports without affecting production

## Validation
- `bash -n deploy-jpx-scraper.sh`
- local container verification for the WSL override path was done during setup
- `go test ./...` was not runnable in this environment because the sandbox blocks Go build/module cache writes outside the workspace